### PR TITLE
Dev-fix-project-cards-display

### DIFF
--- a/src/components/_main/Projects/Projects.tsx
+++ b/src/components/_main/Projects/Projects.tsx
@@ -15,7 +15,7 @@ export function Projects() {
 
   // Stores the groups of cards to be separated into pages
   const [cardGroups, setCardGroups] = useState<(typeof projects)[number][][]>(
-    () => chunkArray(projects, 6)
+    () => chunkArray(projects, 8)
   );
 
   const id = useId();


### PR DESCRIPTION
Increased the cards per page set in the cardGroups state from 6 to 8.

Reason: When it was 6 and page was loaded on a large screen, 8 cards are expected but only 6 load. Then there is a delay before the 2 missing cards appear.

By setting it to the larger number, all cards will properly be displayed on large screens, while not interfering with cards on smaller screens.