### PR TITLE
style: removed scroll-mt style from techstack container

### DIFF
--- a/src/components/_main/TechStack/TechStack.tsx
+++ b/src/components/_main/TechStack/TechStack.tsx
@@ -83,7 +83,7 @@ const techStackData: ITechStackDataProps[] = [
 
 export const TechStack = () => {
   return (
-    <div id="tech" className="relative py-12 min-h-screen scroll-mt-12">
+    <div id="tech" className="relative py-12 min-h-screen">
       {/* Background SVG Image */}
       <FixedBackground svgPath="/background/waves-background.svg" />
 


### PR DESCRIPTION
Removed a scroll-mt style. This caused additional space between the Tech Stack's section's title and the top of the page when the user uses the navbar to navigate to the Tech Stack.